### PR TITLE
Implement Abort() in XZStream and relatives

### DIFF
--- a/Joveler.Compression.XZ.Tests/XZStreamsTests.cs
+++ b/Joveler.Compression.XZ.Tests/XZStreamsTests.cs
@@ -457,5 +457,151 @@ namespace Joveler.Compression.XZ.Tests
             Assert.IsTrue(decompDigest.SequenceEqual(originDigest));
         }
         #endregion
+
+        #region Abort Compress
+        [TestMethod]
+        public void AbortCompress()
+        {
+            AbortCompressTemplate("A.pdf", -1);
+            AbortCompressTemplate("B.txt", -1);
+            AbortCompressTemplate("C.bin", -1);
+
+            AbortCompressTemplate("A.pdf", 1);
+            AbortCompressTemplate("B.txt", 2);
+            AbortCompressTemplate("C.bin", 2);
+        }
+
+        private static void AbortCompressTemplate(string sampleFileName, int threads)
+        {
+            XZCompressOptions compOpts = new XZCompressOptions
+            {
+                Level = LzmaCompLevel.Default,
+            };
+
+            string sampleFile = Path.Combine(TestSetup.SampleDir, sampleFileName);
+
+            using (FileStream sampleFs = new FileStream(sampleFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (MemoryStream rms = new MemoryStream())
+            {
+                XZStream xzs = null;
+                try
+                {
+                    if (threads == -1)
+                    { // Single-thread compression
+                        xzs = new XZStream(rms, compOpts);
+                    }
+                    else if (0 < threads)
+                    { // Multi-thread compression
+                        XZThreadedCompressOptions threadOpts = new XZThreadedCompressOptions
+                        {
+                            Threads = threads,
+                        };
+                        xzs = new XZStream(rms, compOpts, threadOpts);
+                    }
+                    else
+                    {
+                        Assert.Fail($"threads [{threads}] is not a valid test value.");
+                    }
+
+                    sampleFs.CopyTo(xzs);
+
+                    xzs.Abort();
+
+                    // Internal xz resources are now freed. Every compress operation will fail.
+                    sampleFs.Position = 0;
+                    bool hadThrown = false;
+                    try
+                    {
+                        sampleFs.CopyTo(xzs);
+                    }
+                    catch (XZException e)
+                    {
+                        Assert.AreEqual(LzmaRet.ProgError, e.ReturnCode);
+                        hadThrown = true;
+                    }
+                    Assert.IsTrue(hadThrown);
+                }
+                finally
+                {
+                    xzs?.Dispose();
+                    xzs = null;
+                }
+            }
+        }
+        #endregion
+
+        #region Abort Decompress
+        [TestMethod]
+        public void AbortDecompress()
+        {
+            AbortDecompressTemplate("A.xz", -1);
+            AbortDecompressTemplate("B9.xz", -1);
+            AbortDecompressTemplate("C.xz", -1);
+
+            AbortDecompressTemplate("A_mt16.xz", 1);
+            AbortDecompressTemplate("B1_mt16.xz", 2);
+            AbortDecompressTemplate("C.xz", 2);
+        }
+
+        private static void AbortDecompressTemplate(string sampleFileName, int threads)
+        {
+            string xzFile = Path.Combine(TestSetup.SampleDir, sampleFileName);
+
+            XZDecompressOptions decompOpts = new XZDecompressOptions();
+
+            XZStream xzs = null;
+            try
+            {
+                using (FileStream compFs = new FileStream(xzFile, FileMode.Open, FileAccess.Read, FileShare.Read))
+                {
+                    if (threads == -1)
+                    { // Single-thread compression
+                        xzs = new XZStream(compFs, decompOpts);
+                    }
+                    else if (0 < threads)
+                    { // Multi-thread compression
+                        XZThreadedDecompressOptions threadOpts = new XZThreadedDecompressOptions
+                        {
+                            Threads = threads,
+                        };
+                        xzs = new XZStream(compFs, decompOpts, threadOpts);
+                    }
+                    else
+                    {
+                        Assert.Fail($"threads [{threads}] is not a valid test value.");
+                    }
+
+                    long firstReadLen = compFs.Length / 2;
+                    byte[] firstBuffer = new byte[firstReadLen];
+                    int bytesRead = xzs.Read(firstBuffer, 0, firstBuffer.Length);
+
+                    xzs.Abort();
+
+                    // Internal xz resources are now freed. Every decompress operation will fail.
+                    bool hadThrown = false;
+                    try
+                    {
+                        byte[] buffer = new byte[64 * 1024];
+                        do
+                        {
+                            bytesRead = xzs.Read(buffer, 0, buffer.Length);
+                        } while (0 < bytesRead);
+                    }
+                    catch (XZException e)
+                    {
+                        Assert.AreEqual(LzmaRet.ProgError, e.ReturnCode);
+                        hadThrown = true;
+                    }
+                    Assert.IsTrue(hadThrown);
+                }
+            }
+            finally
+            {
+                xzs?.Dispose();
+                xzs = null;
+            }
+            Assert.IsNull(xzs);
+        }
+        #endregion
     }
 }

--- a/Joveler.Compression.XZ/XZStreams.cs
+++ b/Joveler.Compression.XZ/XZStreams.cs
@@ -609,6 +609,10 @@ namespace Joveler.Compression.XZ
         /// </summary>
         public void Abort()
         {
+            // In compress mode, Abort() is faster than Close().
+            // In threaded compress mode, Abort() is much faster than Close().
+            // In decompress mode, Abort() took similar time as Close().
+            
             // Invalidate LzmaStream instance.
             // After running this code, liblzma will refuse any operations via this LzmaStream object.
             if (_isAborted)

--- a/Joveler.Compression.ZLib/ZLibStreams.cs
+++ b/Joveler.Compression.ZLib/ZLibStreams.cs
@@ -84,12 +84,12 @@ namespace Joveler.Compression.ZLib
     }
     #endregion
 
-    #region DeflateBaseStream
+    #region DeflateStreamBase
     /// <summary>
-    /// The stream which compress or decompress deflate stream format.
-    /// <para>This class can be changed anytime, does not rely on this as public stable ABI!</para>
+    /// The stream which compress or decompress zlib-related stream format.
+    /// <para>This symbol can be changed anytime, consider this as not a part of public ABI!</para>
     /// </summary>
-    public abstract class DeflateBaseStream : Stream
+    public abstract class DeflateStreamBase : Stream
     {
         #region enum Mode, Format
         internal enum Mode
@@ -145,7 +145,7 @@ namespace Joveler.Compression.ZLib
         /// <summary>
         /// Create compressing DeflateStream.
         /// </summary>
-        protected DeflateBaseStream(Stream baseStream, ZLibCompressOptions compOpts, Format format)
+        protected DeflateStreamBase(Stream baseStream, ZLibCompressOptions compOpts, Format format)
         {
             ZLibInit.Manager.EnsureLoaded();
 
@@ -167,7 +167,7 @@ namespace Joveler.Compression.ZLib
             ZLibException.CheckReturnValue(ret, _zs);
         }
 
-        protected DeflateBaseStream(Stream baseStream, ZLibDecompressOptions decompOpts, Format format)
+        protected DeflateStreamBase(Stream baseStream, ZLibDecompressOptions decompOpts, Format format)
         {
             ZLibInit.Manager.EnsureLoaded();
 
@@ -205,7 +205,7 @@ namespace Joveler.Compression.ZLib
         #endregion
 
         #region Disposable Pattern
-        ~DeflateBaseStream()
+        ~DeflateStreamBase()
         {
             Dispose(false);
         }
@@ -506,7 +506,7 @@ namespace Joveler.Compression.ZLib
     /// <summary>
     /// The stream which compress or decompress deflate stream format.
     /// </summary>
-    public sealed class DeflateStream : DeflateBaseStream
+    public sealed class DeflateStream : DeflateStreamBase
     {
         /// <summary>
         /// Create compressing DeflateStream.
@@ -527,7 +527,7 @@ namespace Joveler.Compression.ZLib
     /// <summary>
     /// The stream which compress or decompress zlib stream format.
     /// </summary>
-    public sealed class ZLibStream : DeflateBaseStream
+    public sealed class ZLibStream : DeflateStreamBase
     {
         /// <summary>
         /// Create compressing ZLibStream.
@@ -548,7 +548,7 @@ namespace Joveler.Compression.ZLib
     /// /// <summary>
     /// The stream which compress or decompress gzip stream format.
     /// </summary>
-    public sealed class GZipStream : DeflateBaseStream
+    public sealed class GZipStream : DeflateStreamBase
     {
         /// <summary>
         /// Create compressing GZipStream.


### PR DESCRIPTION
## Summary

- Implement the `Abort()` method in `XZStream` and its relatives.
    - Solves the aborting performance issue denoted in #14

## Details

### Why current implementation does not have `Abort()`?

My compression stream implementation follows [.NET BCL's official DeflateStream](https://learn.microsoft.com/en-US/dotnet/api/system.io.compression.deflatestream?view=net-7.0) interface. It does not define `Abort()` or similar method. Many other implementations also have a similar behavior. 

My guess is that zlib is a relatively fast compression algorithm, so merely calling `Close()` was enough even though a user wanted to abort the session.

### When and why `Close()` takes much time?

When closing the `XZStream` (and its relatives), `liblzma` flushes its internal buffer.
- Compress mode: The remaining input buffer must be compressed to finalize an xz file into a proper state.
- Decompress mode: Nothing to do before closing.

In threaded compress mode, `liblzma` aggressively buffers the input data. The compression itself is merely postponed as much as possible. The compression time itself looks shorter, but it goes into the time needed to properly finalize an xz file.

### What does the new `Abort()` do?

It just frees internal liblzma resources. To be exact, it frees `LzmaStream`, the context for the liblzma operation.

It will save up some time on compress mode, especially threaded compression mode. It does not in decompress mode.

Thus, liblzma will refuse any operation after calling `Abort()`. Users must dispose of `XZStream` right after calling `Abort()`.

### Benchmark: How much does `Abort()` save time compared to `Close()`?

Taken from the `AbortCompress` test prints:
- Threaded compression benefits a lot.
```
# Singlethreaded Compression
A.pdf, -1 = Close() took 3.000ms
A.pdf, -1 = Abort() took 1.000ms
B.txt, -1 = Close() took 1.999ms
B.txt, -1 = Abort() took 0.999ms
C.bin, -1 = Close() took 6.999ms
C.bin, -1 = Abort() took 2.000ms
# Multithreaded Compression
A.pdf, 1 = Close() took 20.002ms
A.pdf, 1 = Abort() took 1.000ms
B.txt, 2 = Close() took 8.000ms
B.txt, 2 = Abort() took 0.000ms
C.bin, 2 = Close() took 222.162ms
C.bin, 2 = Abort() took 8.001ms
```